### PR TITLE
Use variable for apt repo

### DIFF
--- a/tasks/apt.yaml
+++ b/tasks/apt.yaml
@@ -4,7 +4,7 @@
 
 - name: Add apt repository
   apt_repository:
-    repo: 'deb https://packagecloud.io/grafana/stable/debian/ wheezy main'
+    repo: "{{ grafana_apt_repo }}"
     state: present
 
 - name: Install Grafana package


### PR DESCRIPTION
The apt repo was hardcoded in the task instead of using the dedicated variable.